### PR TITLE
remove prod key as parameter

### DIFF
--- a/MergeATSClient/api/account_token_api.py
+++ b/MergeATSClient/api/account_token_api.py
@@ -37,17 +37,16 @@ class AccountTokenApi(object):
             api_client = ApiClient()
         self.api_client = api_client
 
-    def account_token_retrieve(self, production_key, public_token, **kwargs):  # noqa: E501
+    def account_token_retrieve(self, public_token, **kwargs):  # noqa: E501
         """account_token_retrieve  # noqa: E501
 
         Returns the account token for the end user with the provided public token.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.account_token_retrieve(production_key, public_token, async_req=True)
+        >>> thread = api.account_token_retrieve(public_token, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
-        :param str production_key: The requesting organization's production key. (required)
         :param str public_token: (required)
         :param _preload_content: if False, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
@@ -61,19 +60,18 @@ class AccountTokenApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        return self.account_token_retrieve_with_http_info(production_key, public_token, **kwargs)  # noqa: E501
+        return self.account_token_retrieve_with_http_info(public_token, **kwargs)  # noqa: E501
 
-    def account_token_retrieve_with_http_info(self, production_key, public_token, **kwargs):  # noqa: E501
+    def account_token_retrieve_with_http_info(self, public_token, **kwargs):  # noqa: E501
         """account_token_retrieve  # noqa: E501
 
         Returns the account token for the end user with the provided public token.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.account_token_retrieve_with_http_info(production_key, public_token, async_req=True)
+        >>> thread = api.account_token_retrieve_with_http_info(public_token, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
-        :param str production_key: The requesting organization's production key. (required)
         :param str public_token: (required)
         :param _return_http_data_only: response data without head status code
                                        and headers
@@ -92,7 +90,6 @@ class AccountTokenApi(object):
         local_var_params = locals()
 
         all_params = [
-            'production_key',
             'public_token'
         ]
         all_params.extend(
@@ -112,10 +109,6 @@ class AccountTokenApi(object):
                 )
             local_var_params[key] = val
         del local_var_params['kwargs']
-        # verify the required parameter 'production_key' is set
-        if self.api_client.client_side_validation and ('production_key' not in local_var_params or  # noqa: E501
-                                                        local_var_params['production_key'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `production_key` when calling `account_token_retrieve`")  # noqa: E501
         # verify the required parameter 'public_token' is set
         if self.api_client.client_side_validation and ('public_token' not in local_var_params or  # noqa: E501
                                                         local_var_params['public_token'] is None):  # noqa: E501
@@ -128,8 +121,6 @@ class AccountTokenApi(object):
             path_params['public_token'] = local_var_params['public_token']  # noqa: E501
 
         query_params = []
-        if 'production_key' in local_var_params and local_var_params['production_key'] is not None:  # noqa: E501
-            query_params.append(('production_key', local_var_params['production_key']))  # noqa: E501
 
         header_params = {}
 

--- a/MergeATSClient/api/link_token_api.py
+++ b/MergeATSClient/api/link_token_api.py
@@ -37,17 +37,16 @@ class LinkTokenApi(object):
             api_client = ApiClient()
         self.api_client = api_client
 
-    def link_token_create(self, production_key, end_user_details, **kwargs):  # noqa: E501
+    def link_token_create(self, end_user_details, **kwargs):  # noqa: E501
         """link_token_create  # noqa: E501
 
         Creates a link token to be used when linking a new end user.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.link_token_create(production_key, end_user_details, async_req=True)
+        >>> thread = api.link_token_create(end_user_details, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
-        :param str production_key: The requesting organization's production key. (required)
         :param EndUserDetails end_user_details: (required)
         :param _preload_content: if False, the urllib3.HTTPResponse object will
                                  be returned without reading/decoding response
@@ -61,19 +60,18 @@ class LinkTokenApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        return self.link_token_create_with_http_info(production_key, end_user_details, **kwargs)  # noqa: E501
+        return self.link_token_create_with_http_info(end_user_details, **kwargs)  # noqa: E501
 
-    def link_token_create_with_http_info(self, production_key, end_user_details, **kwargs):  # noqa: E501
+    def link_token_create_with_http_info(self, end_user_details, **kwargs):  # noqa: E501
         """link_token_create  # noqa: E501
 
         Creates a link token to be used when linking a new end user.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.link_token_create_with_http_info(production_key, end_user_details, async_req=True)
+        >>> thread = api.link_token_create_with_http_info(end_user_details, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
-        :param str production_key: The requesting organization's production key. (required)
         :param EndUserDetails end_user_details: (required)
         :param _return_http_data_only: response data without head status code
                                        and headers
@@ -92,7 +90,6 @@ class LinkTokenApi(object):
         local_var_params = locals()
 
         all_params = [
-            'production_key',
             'end_user_details'
         ]
         all_params.extend(
@@ -112,10 +109,6 @@ class LinkTokenApi(object):
                 )
             local_var_params[key] = val
         del local_var_params['kwargs']
-        # verify the required parameter 'production_key' is set
-        if self.api_client.client_side_validation and ('production_key' not in local_var_params or  # noqa: E501
-                                                        local_var_params['production_key'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `production_key` when calling `link_token_create`")  # noqa: E501
         # verify the required parameter 'end_user_details' is set
         if self.api_client.client_side_validation and ('end_user_details' not in local_var_params or  # noqa: E501
                                                         local_var_params['end_user_details'] is None):  # noqa: E501
@@ -126,8 +119,6 @@ class LinkTokenApi(object):
         path_params = {}
 
         query_params = []
-        if 'production_key' in local_var_params and local_var_params['production_key'] is not None:  # noqa: E501
-            query_params.append(('production_key', local_var_params['production_key']))  # noqa: E501
 
         header_params = {}
 

--- a/MergeATSClient/models/attachment.py
+++ b/MergeATSClient/models/attachment.py
@@ -153,8 +153,8 @@ class Attachment(object):
         :type: str
         """
         if (self.local_vars_configuration.client_side_validation and
-                file_url is not None and len(file_url) > 400):
-            raise ValueError("Invalid value for `file_url`, length must be less than or equal to `400`")  # noqa: E501
+                file_url is not None and len(file_url) > 500):
+            raise ValueError("Invalid value for `file_url`, length must be less than or equal to `500`")  # noqa: E501
 
         self._file_url = file_url
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,10 @@ configuration = MergeATSClient.Configuration(
 with MergeATSClient.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = MergeATSClient.AccountTokenApi(api_client)
-    production_key = 'production_key_example' # str | The requesting organization's production key.
-public_token = 'public_token_example' # str | 
+    public_token = 'public_token_example' # str | 
 
     try:
-        api_response = api_instance.account_token_retrieve(production_key, public_token)
+        api_response = api_instance.account_token_retrieve(public_token)
         pprint(api_response)
     except ApiException as e:
         print("Exception when calling AccountTokenApi->account_token_retrieve: %s\n" % e)

--- a/docs/AccountTokenApi.md
+++ b/docs/AccountTokenApi.md
@@ -8,7 +8,7 @@ Method | HTTP request | Description
 
 
 # **account_token_retrieve**
-> AccountToken account_token_retrieve(production_key, public_token)
+> AccountToken account_token_retrieve(public_token)
 
 
 
@@ -48,11 +48,10 @@ configuration = MergeATSClient.Configuration(
 with MergeATSClient.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = MergeATSClient.AccountTokenApi(api_client)
-    production_key = 'production_key_example' # str | The requesting organization's production key.
-public_token = 'public_token_example' # str | 
+    public_token = 'public_token_example' # str | 
 
     try:
-        api_response = api_instance.account_token_retrieve(production_key, public_token)
+        api_response = api_instance.account_token_retrieve(public_token)
         pprint(api_response)
     except ApiException as e:
         print("Exception when calling AccountTokenApi->account_token_retrieve: %s\n" % e)
@@ -62,7 +61,6 @@ public_token = 'public_token_example' # str |
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **production_key** | **str**| The requesting organization&#39;s production key. | 
  **public_token** | **str**|  | 
 
 ### Return type

--- a/docs/LinkTokenApi.md
+++ b/docs/LinkTokenApi.md
@@ -8,7 +8,7 @@ Method | HTTP request | Description
 
 
 # **link_token_create**
-> LinkToken link_token_create(production_key, end_user_details)
+> LinkToken link_token_create(end_user_details)
 
 
 
@@ -48,11 +48,10 @@ configuration = MergeATSClient.Configuration(
 with MergeATSClient.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = MergeATSClient.LinkTokenApi(api_client)
-    production_key = 'production_key_example' # str | The requesting organization's production key.
-end_user_details = MergeATSClient.EndUserDetails() # EndUserDetails | 
+    end_user_details = MergeATSClient.EndUserDetails() # EndUserDetails | 
 
     try:
-        api_response = api_instance.link_token_create(production_key, end_user_details)
+        api_response = api_instance.link_token_create(end_user_details)
         pprint(api_response)
     except ApiException as e:
         print("Exception when calling LinkTokenApi->link_token_create: %s\n" % e)
@@ -62,7 +61,6 @@ end_user_details = MergeATSClient.EndUserDetails() # EndUserDetails |
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **production_key** | **str**| The requesting organization&#39;s production key. | 
  **end_user_details** | [**EndUserDetails**](EndUserDetails.md)|  | 
 
 ### Return type


### PR DESCRIPTION
## Description of the change

> No longer need production key for token endpoints since it's in the Auth header

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://app.asana.com/0/1198154734771987/1199605205111638/f

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
